### PR TITLE
Adding php5.5 build for default image. Commented out dotnet images fo…

### DIFF
--- a/ansible/roles/ubuntu-php5.5/defaults/main.yml
+++ b/ansible/roles/ubuntu-php5.5/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+
+memory_limit: '128M'
+error_reporting: 'E_ALL & ~E_DEPRECATED & ~E_STRICT'
+expose_php: 'Off'
+display_errors: 'Off'
+display_startup_errors: 'Off'
+post_max_size: '8M'
+upload_max_filesize: '2M'

--- a/ansible/roles/ubuntu-php5.5/tasks/main.yml
+++ b/ansible/roles/ubuntu-php5.5/tasks/main.yml
@@ -14,16 +14,13 @@
     - 'php5-gd'
     - 'php5-json'
     - 'php5-ldap'
-    - 'php5-mbstring'
     - 'php5-mcrypt'
     - 'php5-mysql'
     - 'php5-readline'
-    - 'php5-xml'
     - 'libapache2-mod-php5'
-    - 'php-redis'
+    - 'php5-redis'
     - 'php5-imagick'
     - 'php-pear'
-    - 'php-uploadprogress'
     - 'imagemagick'
 
 - name: install redis

--- a/ansible/roles/ubuntu-php5.5/tasks/main.yml
+++ b/ansible/roles/ubuntu-php5.5/tasks/main.yml
@@ -1,0 +1,50 @@
+---
+
+- name: update apt
+  apt: update_cache=yes
+  when: phpaptrepo.changed
+
+- name: install php dependencies
+  apt: name={{ item }} state=present
+  with_items:
+    - 'php5'
+    - 'php5-cli'
+    - 'php5-common'
+    - 'php5-curl'
+    - 'php5-dev'
+    - 'php5-gd'
+    - 'php5-json'
+    - 'php5-ldap'
+    - 'php5-mbstring'
+    - 'php5-mcrypt'
+    - 'php5-mysql'
+    - 'php5-readline'
+    - 'php5-xml'
+    - 'libapache2-mod-php5'
+    - 'php-redis'
+    - 'php5-imagick'
+    - 'php-pear'
+    - 'php-uploadprogress'
+    - 'imagemagick'
+
+- name: install redis
+  apt:
+    name: redis-server
+    state: present
+
+- name: install memcached
+  apt:
+    name: memcached
+    state: present
+
+- name: install libzip
+  apt:
+    name: libzip-dev
+    state: present
+
+- name: install php zip
+  pear:
+    name: pecl/zip
+    state: present
+
+- import_tasks: php-ini.yml

--- a/ansible/roles/ubuntu-php5.5/tasks/main.yml
+++ b/ansible/roles/ubuntu-php5.5/tasks/main.yml
@@ -2,7 +2,6 @@
 
 - name: update apt
   apt: update_cache=yes
-  when: phpaptrepo.changed
 
 - name: install php dependencies
   apt: name={{ item }} state=present

--- a/ansible/roles/ubuntu-php5.5/tasks/php-ini.yml
+++ b/ansible/roles/ubuntu-php5.5/tasks/php-ini.yml
@@ -2,7 +2,7 @@
 
 - name: 'set php ini values'
   lineinfile:
-    path: /etc/php/5/apache2/php.ini
+    path: /etc/php5/apache2/php.ini
     regexp: '^{{ item.name }}'
     line: 'upload_max_filesize = {{ item.value }}'
   with_items:

--- a/ansible/roles/ubuntu-php5.5/tasks/php-ini.yml
+++ b/ansible/roles/ubuntu-php5.5/tasks/php-ini.yml
@@ -1,0 +1,15 @@
+---
+
+- name: 'set php ini values'
+  lineinfile:
+    path: /etc/php/5/apache2/php.ini
+    regexp: '^{{ item.name }}'
+    line: 'upload_max_filesize = {{ item.value }}'
+  with_items:
+    - { name: 'memory_limit', value: '{{ memory_limit }}' }
+    - { name: 'error_reporting', value: '{{ error_reporting }}' }
+    - { name: 'expose_php', value: '{{ expose_php }}' }
+    - { name: 'display_errors', value: '{{ display_errors }}' }
+    - { name: 'display_startup_errors', value: '{{ display_startup_errors }}' }
+    - { name: 'post_max_size', value: '{{ post_max_size }}' }
+    - { name: 'upload_max_filesize', value: '{{ upload_max_filesize }}' }

--- a/ansible/ubuntu-php5.5.yml
+++ b/ansible/ubuntu-php5.5.yml
@@ -9,5 +9,5 @@
     - { role: 'ubuntu-apache' }
     - { role: 'ubuntu-varnish' }
     - { role: 'ubuntu-nodejs' }
-    - { role: 'ubuntu-php5.6' }
+    - { role: 'ubuntu-php5.5' }
     - { role: 'ubuntu-probo' }

--- a/ansible/ubuntu-php5.5.yml
+++ b/ansible/ubuntu-php5.5.yml
@@ -1,0 +1,13 @@
+---
+- hosts: all
+  become: yes
+  become_method: sudo
+
+  roles:
+    - { role: 'ubuntu-base' }
+    - { role: 'ubuntu-mysql' }
+    - { role: 'ubuntu-apache' }
+    - { role: 'ubuntu-varnish' }
+    - { role: 'ubuntu-nodejs' }
+    - { role: 'ubuntu-php5.6' }
+    - { role: 'ubuntu-probo' }

--- a/builder/14.04-php5.5/Dockerfile
+++ b/builder/14.04-php5.5/Dockerfile
@@ -1,0 +1,2 @@
+FROM proboci/ubuntu-14.04-lamp:php5.5-intermediary
+ENV PATH "~/.composer/vendor/bin:$PATH"

--- a/builder/14.04-php5.5/ubuntu-14.04-lamp.json
+++ b/builder/14.04-php5.5/ubuntu-14.04-lamp.json
@@ -1,0 +1,39 @@
+{
+  "builders": [
+    {
+      "type": "docker",
+      "image": "ubuntu:14.04",
+      "pull": true,
+      "commit": true
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "shell",
+      "script": "../ansible.sh"
+    },
+    {
+      "type": "ansible-local",
+      "playbook_file": "../../ansible/ubuntu-php5.5.yml",
+      "extra_arguments": ["-e", "varnish_version=3"],
+      "role_paths": [
+        "../../ansible/roles/ubuntu-apache",
+        "../../ansible/roles/ubuntu-base",
+        "../../ansible/roles/ubuntu-mysql",
+        "../../ansible/roles/ubuntu-nodejs",
+        "../../ansible/roles/ubuntu-php5.5",
+        "../../ansible/roles/ubuntu-varnish",
+        "../../ansible/roles/ubuntu-probo"
+      ]
+    }
+  ],
+  "post-processors": [
+    [
+      {
+        "type": "docker-tag",
+        "tag": "php5.5-intermediary",
+        "repository": "proboci/ubuntu-14.04-lamp"
+      }
+    ]
+  ]
+}

--- a/scripts/build_images.sh
+++ b/scripts/build_images.sh
@@ -17,33 +17,33 @@ build_ubuntu-14.04-lamp-php5.5 () {
 build_ubuntu-14.04-lamp-php5.6 () {
 	cd $BUILDER/14.04-php5.6
 	$PACKER build ubuntu-14.04-lamp.json
-	echo -e "${INFO}Building proboci/ubuntu-14.04-lamp:php5.6-nightly...${NC}"
-	docker build --compress -t="proboci/ubuntu-14.04-lamp:php5.6-nightly" .
-	echo -e "${INFO}Image proboci/ubuntu-14.04-lamp:php5.6-nightly built.${NC}"
+	echo -e "${INFO}Building proboci/ubuntu-14.04-lamp:php-5.6 and proboci/ubuntu-14.04-lamp:5.6-beta images...${NC}"
+	docker build --compress -t="proboci/ubuntu-14.04-lamp:php-5.6" -t="proboci/ubuntu-14.04-lamp:5.6-beta" .
+	echo -e "${INFO}Images for proboci/ubuntu-14.04-lamp:php-5.6 and proboci/ubuntu-14.04-lamp:5.6-beta built.${NC}"
 }
 
 build_ubuntu-14.04-lamp-php7.0 () {
 	cd $BUILDER/14.04-php7.0
 	$PACKER build ubuntu-14.04-lamp.json
-	echo -e "${INFO}Building proboci/ubuntu-14.04-lamp:php7.0-nightly...${NC}"
-	docker build --compress -t="proboci/ubuntu-14.04-lamp:php7.0-nightly" .
-	echo -e "${INFO}Image proboci/ubuntu-14.04-lamp:php7.0-nightly built.${NC}"
+	echo -e "${INFO}Building proboci/ubuntu-14.04-lamp:php-7.0 and proboci/ubuntu-14.04-lamp:7.0-beta images...${NC}"
+	docker build --compress -t="proboci/ubuntu-14.04-lamp:php-7.0" -t="proboci/ubuntu-14.04-lamp:7.0-beta" .
+	echo -e "${INFO}Images for proboci/ubuntu-14.04-lamp:php-7.0 and proboci/ubuntu-14.04-lamp:7.0-beta built.${NC}"
 }
 
 build_ubuntu-14.04-lamp-php7.1 () {
 	cd $BUILDER/14.04-php7.1
 	$PACKER build ubuntu-14.04-lamp.json
-	echo -e "${INFO}Building proboci/ubuntu-14.04-lamp:php7.1-nightly...${NC}"
-	docker build --compress -t="proboci/ubuntu-14.04-lamp:php7.1-nightly" .
-	echo -e "${INFO}Image proboci/ubuntu-14.04-lamp:php7.1-nightly built.${NC}"
+	echo -e "${INFO}Building proboci/ubuntu-14.04-lamp:php-7.1 and proboci/ubuntu-14.04-lamp:7.1-beta images...${NC}"
+	docker build --compress -t="proboci/ubuntu-14.04-lamp:php-7.1" -t="proboci/ubuntu-14.04-lamp:7.1-beta" .
+	echo -e "${INFO}Images for proboci/ubuntu-14.04-lamp:php-7.1 and proboci/ubuntu-14.04-lamp:7.1-beta built.${NC}"
 }
 
 build_ubuntu-14.04-lamp-php7.2 () {
 	cd $BUILDER/14.04-php7.2
 	$PACKER build ubuntu-14.04-lamp.json
-	echo -e "${INFO}Building proboci/ubuntu-14.04-lamp:php7.2-nightly...${NC}"
-	docker build --compress -t="proboci/ubuntu-14.04-lamp:php7.2-nightly" .
-	echo -e "${INFO}Image proboci/ubuntu-14.04-lamp:php7.2-nightly built.${NC}"
+	echo -e "${INFO}Building proboci/ubuntu-14.04-lamp:php-7.2 and proboci/ubuntu-14.04-lamp:php-7.2-beta images...${NC}"
+	docker build --compress -t="proboci/ubuntu-14.04-lamp:php-7.2" -t="proboci/ubuntu-14.04-lamp:php-7.2-beta" .
+	echo -e "${INFO}Images for proboci/ubuntu-14.04-lamp:php-7.2 and proboci/ubuntu-14.04-lamp:php-7.2-beta built.${NC}"
 }
 
 build_ubuntu-16.04-dotnet-sdk1.0.1 () {
@@ -65,25 +65,25 @@ build_ubuntu-16.04-dotnet-sdk2.0.2 () {
 build_ubuntu-16.04-lamp-php7.0 () {
 	cd $BUILDER/16.04-php7.0
 	$PACKER build ubuntu-16.04-lamp.json
-	echo -e "${INFO}Building proboci/ubuntu-16.04-lamp:php7.0-nightly...${NC}"
-	docker build --compress -t="proboci/ubuntu-16.04-lamp:php7.0-nightly" .
-	echo -e "${INFO}Image proboci/ubuntu-16.04-lamp:php7.0-nightly built.${NC}"
+	echo -e "${INFO}Building proboci/ubuntu-16.04-lamp:php-7.0...${NC}"
+	docker build --compress -t="proboci/ubuntu-16.04-lamp:php-7.0" .
+	echo -e "${INFO}Image proboci/ubuntu-16.04-lamp:php-7.0 built.${NC}"
 }
 
 build_ubuntu-16.04-lamp-php7.1 () {
 	cd $BUILDER/16.04-php7.1
 	$PACKER build ubuntu-16.04-lamp.json
-	echo -e "${INFO}Building proboci/ubuntu-16.04-lamp:php7.1-nightly...${NC}"
-	docker build --compress -t="proboci/ubuntu-16.04-lamp:php7.1-nightly" .
-	echo -e "${INFO}Image proboci/ubuntu-16.04-lamp:php7.1-nightly built.${NC}"
+	echo -e "${INFO}Building proboci/ubuntu-16.04-lamp:php-7.1...${NC}"
+	docker build --compress -t="proboci/ubuntu-16.04-lamp:php-7.1" .
+	echo -e "${INFO}Image proboci/ubuntu-16.04-lamp:php-7.1 built.${NC}"
 }
 
 build_ubuntu-16.04-lamp-php7.2 () {
 	cd $BUILDER/16.04-php7.2
 	$PACKER build ubuntu-16.04-lamp.json
-	echo -e "${INFO}Building proboci/ubuntu-16.04-lamp:php7.2-nightly...${NC}"
-	docker build --compress -t="proboci/ubuntu-16.04-lamp:php7.2-nightly" .
-	echo -e "${INFO}Image proboci/ubuntu-16.04-lamp:php7.2-nightly built.${NC}"
+	echo -e "${INFO}Building proboci/ubuntu-16.04-lamp:php-7.2...${NC}"
+	docker build --compress -t="proboci/ubuntu-16.04-lamp:php-7.2" .
+	echo -e "${INFO}Image proboci/ubuntu-16.04-lamp:php-7.2 built.${NC}"
 }
 
 # Build LAMP images.

--- a/scripts/build_images.sh
+++ b/scripts/build_images.sh
@@ -6,6 +6,14 @@ NC='\033[0m' # No Color
 PACKER=/usr/local/bin/packer
 BUILDER=/vagrant/builder
 
+build_ubuntu-14.04-lamp-php5.5 () {
+	cd $BUILDER/14.04-php5.5
+	$PACKER build ubuntu-14.04-lamp.json
+	echo -e "${INFO}Building proboci/ubuntu-14.04-lamp and proboci/ubuntu-14.04-lamp:beta images...${NC}"
+	docker build --compress -t="proboci/ubuntu-14.04-lamp" -t="proboci/ubuntu-14.04-lamp:beta" .
+	echo -e "${INFO}Images for proboci/ubuntu-14.04-lamp and proboci/ubuntu-14.04-lamp:betabuilt.${NC}"
+}
+
 build_ubuntu-14.04-lamp-php5.6 () {
 	cd $BUILDER/14.04-php5.6
 	$PACKER build ubuntu-14.04-lamp.json
@@ -79,6 +87,7 @@ build_ubuntu-16.04-lamp-php7.2 () {
 }
 
 # Build LAMP images.
+build_ubuntu-14.04-lamp-php5.5
 build_ubuntu-14.04-lamp-php5.6
 build_ubuntu-14.04-lamp-php7.0
 build_ubuntu-14.04-lamp-php7.1
@@ -88,5 +97,5 @@ build_ubuntu-16.04-lamp-php7.1
 build_ubuntu-16.04-lamp-php7.2
 
 # Build .NET images.
-build_ubuntu-16.04-dotnet-sdk1.0.1
-build_ubuntu-16.04-dotnet-sdk2.0.2
+#build_ubuntu-16.04-dotnet-sdk1.0.1
+#build_ubuntu-16.04-dotnet-sdk2.0.2

--- a/scripts/build_images.sh
+++ b/scripts/build_images.sh
@@ -9,41 +9,129 @@ BUILDER=/vagrant/builder
 build_ubuntu-14.04-lamp-php5.5 () {
 	cd $BUILDER/14.04-php5.5
 	$PACKER build ubuntu-14.04-lamp.json
-	echo -e "${INFO}Building proboci/ubuntu-14.04-lamp and proboci/ubuntu-14.04-lamp:beta images...${NC}"
-	docker build --compress -t="proboci/ubuntu-14.04-lamp" -t="proboci/ubuntu-14.04-lamp:beta" .
-	echo -e "${INFO}Images for proboci/ubuntu-14.04-lamp and proboci/ubuntu-14.04-lamp:beta built.${NC}"
+	echo -e "${INFO}Building proboci/ubuntu-14.04-lamp image...${NC}"
+	docker build --compress -t="proboci/ubuntu-14.04-lamp:latest" .
+	echo -e "${INFO}Image proboci/ubuntu-14.04-lamp:latest built.${NC}"
+}
+
+build_ubuntu-14.04-lamp-php5.5-beta () {
+	cd $BUILDER/14.04-php5.5
+	$PACKER build ubuntu-14.04-lamp.json
+	echo -e "${INFO}Building proboci/ubuntu-14.04-lamp:beta image...${NC}"
+	docker build --compress -t="proboci/ubuntu-14.04-lamp:beta" .
+	echo -e "${INFO}Image proboci/ubuntu-14.04-lamp:beta built.${NC}"
 }
 
 build_ubuntu-14.04-lamp-php5.6 () {
 	cd $BUILDER/14.04-php5.6
 	$PACKER build ubuntu-14.04-lamp.json
-	echo -e "${INFO}Building proboci/ubuntu-14.04-lamp:php-5.6 and proboci/ubuntu-14.04-lamp:5.6-beta images...${NC}"
-	docker build --compress -t="proboci/ubuntu-14.04-lamp:php-5.6" -t="proboci/ubuntu-14.04-lamp:5.6-beta" .
-	echo -e "${INFO}Images for proboci/ubuntu-14.04-lamp:php-5.6 and proboci/ubuntu-14.04-lamp:5.6-beta built.${NC}"
+	echo -e "${INFO}Building proboci/ubuntu-14.04-lamp:php-5.6 image...${NC}"
+	docker build --compress -t="proboci/ubuntu-14.04-lamp:php-5.6" .
+	echo -e "${INFO}Image proboci/ubuntu-14.04-lamp:php-5.6 built.${NC}"
+}
+
+build_ubuntu-14.04-lamp-php5.6-beta () {
+	cd $BUILDER/14.04-php5.6
+	$PACKER build ubuntu-14.04-lamp.json
+	echo -e "${INFO}Building proboci/ubuntu-14.04-lamp:5.6-beta image...${NC}"
+	docker build --compress -t="proboci/ubuntu-14.04-lamp:5.6-beta" .
+	echo -e "${INFO}Image proboci/ubuntu-14.04-lamp:5.6-beta built.${NC}"
 }
 
 build_ubuntu-14.04-lamp-php7.0 () {
 	cd $BUILDER/14.04-php7.0
 	$PACKER build ubuntu-14.04-lamp.json
-	echo -e "${INFO}Building proboci/ubuntu-14.04-lamp:php-7.0 and proboci/ubuntu-14.04-lamp:7.0-beta images...${NC}"
-	docker build --compress -t="proboci/ubuntu-14.04-lamp:php-7.0" -t="proboci/ubuntu-14.04-lamp:7.0-beta" .
-	echo -e "${INFO}Images for proboci/ubuntu-14.04-lamp:php-7.0 and proboci/ubuntu-14.04-lamp:7.0-beta built.${NC}"
+	echo -e "${INFO}Building proboci/ubuntu-14.04-lamp:php-7.0 image...${NC}"
+	docker build --compress -t="proboci/ubuntu-14.04-lamp:php-7.0" .
+	echo -e "${INFO}Image proboci/ubuntu-14.04-lamp:php-7.0 built.${NC}"
+}
+
+build_ubuntu-14.04-lamp-php7.0-beta () {
+	cd $BUILDER/14.04-php7.0
+	$PACKER build ubuntu-14.04-lamp.json
+	echo -e "${INFO}Building proboci/ubuntu-14.04-lamp:7.0-beta image...${NC}"
+	docker build --compress -t="proboci/ubuntu-14.04-lamp:7.0-beta" .
+	echo -e "${INFO}Image proboci/ubuntu-14.04-lamp:7.0-beta built.${NC}"
 }
 
 build_ubuntu-14.04-lamp-php7.1 () {
 	cd $BUILDER/14.04-php7.1
 	$PACKER build ubuntu-14.04-lamp.json
-	echo -e "${INFO}Building proboci/ubuntu-14.04-lamp:php-7.1 and proboci/ubuntu-14.04-lamp:7.1-beta images...${NC}"
-	docker build --compress -t="proboci/ubuntu-14.04-lamp:php-7.1" -t="proboci/ubuntu-14.04-lamp:7.1-beta" .
-	echo -e "${INFO}Images for proboci/ubuntu-14.04-lamp:php-7.1 and proboci/ubuntu-14.04-lamp:7.1-beta built.${NC}"
+	echo -e "${INFO}Building proboci/ubuntu-14.04-lamp:php-7.1 image...${NC}"
+	docker build --compress -t="proboci/ubuntu-14.04-lamp:php-7.1" .
+	echo -e "${INFO}Image proboci/ubuntu-14.04-lamp:php-7.1 built.${NC}"
+}
+
+build_ubuntu-14.04-lamp-php7.1-beta () {
+	cd $BUILDER/14.04-php7.1
+	$PACKER build ubuntu-14.04-lamp.json
+	echo -e "${INFO}Building proboci/ubuntu-14.04-lamp:7.1-beta image...${NC}"
+	docker build --compress -t="proboci/ubuntu-14.04-lamp:7.1-beta" .
+	echo -e "${INFO}Image roboci/ubuntu-14.04-lamp:7.1-beta built.${NC}"
 }
 
 build_ubuntu-14.04-lamp-php7.2 () {
 	cd $BUILDER/14.04-php7.2
 	$PACKER build ubuntu-14.04-lamp.json
-	echo -e "${INFO}Building proboci/ubuntu-14.04-lamp:php-7.2 and proboci/ubuntu-14.04-lamp:php-7.2-beta images...${NC}"
-	docker build --compress -t="proboci/ubuntu-14.04-lamp:php-7.2" -t="proboci/ubuntu-14.04-lamp:php-7.2-beta" .
-	echo -e "${INFO}Images for proboci/ubuntu-14.04-lamp:php-7.2 and proboci/ubuntu-14.04-lamp:php-7.2-beta built.${NC}"
+	echo -e "${INFO}Building proboci/ubuntu-14.04-lamp:php-7.2 image...${NC}"
+	docker build --compress -t="proboci/ubuntu-14.04-lamp:php-7.2" .
+	echo -e "${INFO}Image proboci/ubuntu-14.04-lamp:php-7.2 built.${NC}"
+}
+
+build_ubuntu-14.04-lamp-php7.2-beta () {
+	cd $BUILDER/14.04-php7.2
+	$PACKER build ubuntu-14.04-lamp.json
+	echo -e "${INFO}Building proboci/ubuntu-14.04-lamp:php-7.2-beta image...${NC}"
+	docker build --compress -t="proboci/ubuntu-14.04-lamp:php-7.2-beta" .
+	echo -e "${INFO}Image proboci/ubuntu-14.04-lamp:php-7.2-beta built.${NC}"
+}
+
+build_ubuntu-16.04-lamp-php7.0 () {
+	cd $BUILDER/16.04-php7.0
+	$PACKER build ubuntu-16.04-lamp.json
+	echo -e "${INFO}Building proboci/ubuntu-16.04-lamp:php-7.0 image...${NC}"
+	docker build --compress -t="proboci/ubuntu-16.04-lamp:php-7.0" .
+	echo -e "${INFO}Image proboci/ubuntu-16.04-lamp:php-7.0 built.${NC}"
+}
+
+build_ubuntu-16.04-lamp-php7.0-beta () {
+	cd $BUILDER/16.04-php7.0
+	$PACKER build ubuntu-16.04-lamp.json
+	echo -e "${INFO}Building proboci/ubuntu-16.04-lamp:7.0-beta image...${NC}"
+	docker build --compress -t="proboci/ubuntu-16.04-lamp:7.0-beta" .
+	echo -e "${INFO}Image proboci/ubuntu-16.04-lamp:7.0-beta built.${NC}"
+}
+
+build_ubuntu-16.04-lamp-php7.1 () {
+	cd $BUILDER/16.04-php7.1
+	$PACKER build ubuntu-16.04-lamp.json
+	echo -e "${INFO}Building proboci/ubuntu-16.04-lamp:php-7.1 image...${NC}"
+	docker build --compress -t="proboci/ubuntu-16.04-lamp:php-7.1" .
+	echo -e "${INFO}Images for proboci/ubuntu-16.04-lamp:php-7.1 built.${NC}"
+}
+
+build_ubuntu-16.04-lamp-php7.1-beta () {
+	cd $BUILDER/16.04-php7.1
+	$PACKER build ubuntu-16.04-lamp.json
+	echo -e "${INFO}Building proboci/ubuntu-16.04-lamp:7.1-beta image...${NC}"
+	docker build --compress -t="proboci/ubuntu-16.04-lamp:7.1-beta" .
+	echo -e "${INFO}Image proboci/ubuntu-16.04-lamp:7.1-beta built.${NC}"
+}
+
+build_ubuntu-16.04-lamp-php7.2 () {
+	cd $BUILDER/16.04-php7.2
+	$PACKER build ubuntu-16.04-lamp.json
+	echo -e "${INFO}Building proboci/ubuntu-16.04-lamp:php-7.2 image...${NC}"
+	docker build --compress -t="proboci/ubuntu-16.04-lamp:php-7.2" .
+	echo -e "${INFO}Image proboci/ubuntu-16.04-lamp:php-7.2 built.${NC}"
+}
+
+build_ubuntu-16.04-lamp-php7.2-beta () {
+	cd $BUILDER/16.04-php7.2
+	$PACKER build ubuntu-16.04-lamp.json
+	echo -e "${INFO}Building proboci/ubuntu-16.04-lamp:7.2-beta image...${NC}"
+	docker build --compress -t="proboci/ubuntu-16.04-lamp:7.2-beta" .
+	echo -e "${INFO}Image proboci/ubuntu-16.04-lamp:7.2-beta built.${NC}"
 }
 
 build_ubuntu-16.04-dotnet-sdk1.0.1 () {
@@ -62,43 +150,46 @@ build_ubuntu-16.04-dotnet-sdk2.0.2 () {
 	echo -e "${INFO}Image proboci/ubuntu-16.04-dotnet:sdk2.0.2 built.${NC}"
 }
 
-build_ubuntu-16.04-lamp-php7.0 () {
-	cd $BUILDER/16.04-php7.0
-	$PACKER build ubuntu-16.04-lamp.json
-	echo -e "${INFO}Building proboci/ubuntu-16.04-lamp:php-7.0 and proboci/ubuntu-16.04-lamp:7.0-beta images...${NC}"
-	docker build --compress -t="proboci/ubuntu-16.04-lamp:php-7.0" -t="proboci/ubuntu-16.04-lamp:7.0-beta" .
-	echo -e "${INFO}Images for proboci/ubuntu-16.04-lamp:php-7.0 and proboci/ubuntu-16.04-lamp:7.0-beta built.${NC}"
+build_ubuntu-14.04-beta-images () {
+	# Build Ubuntu LAMP 14.04 PHP Beta Images
+	build_ubuntu-14.04-lamp-php5.5-beta
+	build_ubuntu-14.04-lamp-php5.6-beta
+	build_ubuntu-14.04-lamp-php7.0-beta
+	build_ubuntu-14.04-lamp-php7.1-beta
+	build_ubuntu-14.04-lamp-php7.2-beta
 }
 
-build_ubuntu-16.04-lamp-php7.1 () {
-	cd $BUILDER/16.04-php7.1
-	$PACKER build ubuntu-16.04-lamp.json
-	echo -e "${INFO}Building proboci/ubuntu-16.04-lamp:php-7.1 and proboci/ubuntu-16.04-lamp:7.1-beta images...${NC}"
-	docker build --compress -t="proboci/ubuntu-16.04-lamp:php-7.1" -t="proboci/ubuntu-16.04-lamp:7.1-beta" .
-	echo -e "${INFO}Images for proboci/ubuntu-16.04-lamp:php-7.1 and proboci/ubuntu-16.04-lamp:7.1-beta built.${NC}"
+build_ubuntu-14.04-stable-images () {
+	# Build Ubuntu LAMP 14.04 PHP Stable Images
+	build_ubuntu-14.04-lamp-php5.5
+	build_ubuntu-14.04-lamp-php5.6
+	build_ubuntu-14.04-lamp-php7.0
+	build_ubuntu-14.04-lamp-php7.1
+	build_ubuntu-14.04-lamp-php7.2
 }
 
-build_ubuntu-16.04-lamp-php7.2 () {
-	cd $BUILDER/16.04-php7.2
-	$PACKER build ubuntu-16.04-lamp.json
-	echo -e "${INFO}Building proboci/ubuntu-16.04-lamp:php-7.2 and proboci/ubuntu-16.04-lamp:7.2-beta images...${NC}"
-	docker build --compress -t="proboci/ubuntu-16.04-lamp:php-7.2" -t="proboci/ubuntu-16.04-lamp:7.2-beta" .
-	echo -e "${INFO}Images for proboci/ubuntu-16.04-lamp:php-7.2 and proboci/ubuntu-16.04-lamp:7.2-beta built.${NC}"
+build_ubuntu-16.04-beta-images () {
+	# Build Ubuntu LAMP 16.04 PHP Beta Images
+	build_ubuntu-16.04-lamp-php7.0-beta
+	build_ubuntu-16.04-lamp-php7.1-beta
+	build_ubuntu-16.04-lamp-php7.2-beta
 }
 
-# Build LAMP images.
-# Ubuntu LAMP 14.04 PHP Images
-build_ubuntu-14.04-lamp-php5.5
-build_ubuntu-14.04-lamp-php5.6
-build_ubuntu-14.04-lamp-php7.0
-build_ubuntu-14.04-lamp-php7.1
-build_ubuntu-14.04-lamp-php7.2
+build_ubuntu-16.04-stable-images () {
+	# Build Ubuntu LAMP 16.04 PHP Stable Images
+	build_ubuntu-16.04-lamp-php7.0
+	build_ubuntu-16.04-lamp-php7.1
+	build_ubuntu-16.04-lamp-php7.2
+}
 
-# Ubuntu LAMP 16.04 PHP Images
-build_ubuntu-16.04-lamp-php7.0
-build_ubuntu-16.04-lamp-php7.1
-build_ubuntu-16.04-lamp-php7.2
+build_dotnet-core-images () {
+	# Build .NET images.
+	build_ubuntu-16.04-dotnet-sdk1.0.1
+	build_ubuntu-16.04-dotnet-sdk2.0.2
+}
 
-# Build .NET images.
-#build_ubuntu-16.04-dotnet-sdk1.0.1
-#build_ubuntu-16.04-dotnet-sdk2.0.2
+#build_ubuntu-14.04-beta-images
+build_ubuntu-14.04-stable-images
+#build_ubuntu-16.04-beta-images
+build_ubuntu-16.04-stable-images
+#build_dotnet-core-images

--- a/scripts/build_images.sh
+++ b/scripts/build_images.sh
@@ -11,7 +11,7 @@ build_ubuntu-14.04-lamp-php5.5 () {
 	$PACKER build ubuntu-14.04-lamp.json
 	echo -e "${INFO}Building proboci/ubuntu-14.04-lamp and proboci/ubuntu-14.04-lamp:beta images...${NC}"
 	docker build --compress -t="proboci/ubuntu-14.04-lamp" -t="proboci/ubuntu-14.04-lamp:beta" .
-	echo -e "${INFO}Images for proboci/ubuntu-14.04-lamp and proboci/ubuntu-14.04-lamp:betabuilt.${NC}"
+	echo -e "${INFO}Images for proboci/ubuntu-14.04-lamp and proboci/ubuntu-14.04-lamp:beta built.${NC}"
 }
 
 build_ubuntu-14.04-lamp-php5.6 () {
@@ -49,49 +49,52 @@ build_ubuntu-14.04-lamp-php7.2 () {
 build_ubuntu-16.04-dotnet-sdk1.0.1 () {
 	cd $BUILDER/16.04-dotnetsdk1.0.1
 	$PACKER build ubuntu-16.04-dotnet.json
-	echo -e "${INFO}Building proboci/ubuntu-16.04-dotnet:sdk1.0.1-nightly...${NC}"
-	docker build --compress -t="proboci/ubuntu-16.04-dotnet:sdk1.0.1-nightly" .
-	echo -e "${INFO}Image proboci/ubuntu-16.04-dotnet:sdk1.0.1-nightly built.${NC}"
+	echo -e "${INFO}Building proboci/ubuntu-16.04-dotnet:sdk1.0.1...${NC}"
+	docker build --compress -t="proboci/ubuntu-16.04-dotnet:sdk1.0.1" .
+	echo -e "${INFO}Image proboci/ubuntu-16.04-dotnet:sdk1.0.1 built.${NC}"
 }
 
 build_ubuntu-16.04-dotnet-sdk2.0.2 () {
 	cd $BUILDER/16.04-dotnetsdk2.0.2
 	$PACKER build ubuntu-16.04-dotnet.json
-	echo -e "${INFO}Building proboci/ubuntu-16.04-dotnet:sdk2.0.2-nightly...${NC}"
-	docker build --compress -t="proboci/ubuntu-16.04-dotnet:sdk2.0.2-nightly" .
-	echo -e "${INFO}Image proboci/ubuntu-16.04-dotnet:sdk2.0.2-nightly built.${NC}"
+	echo -e "${INFO}Building proboci/ubuntu-16.04-dotnet:sdk2.0.2...${NC}"
+	docker build --compress -t="proboci/ubuntu-16.04-dotnet:sdk2.0.2" .
+	echo -e "${INFO}Image proboci/ubuntu-16.04-dotnet:sdk2.0.2 built.${NC}"
 }
 
 build_ubuntu-16.04-lamp-php7.0 () {
 	cd $BUILDER/16.04-php7.0
 	$PACKER build ubuntu-16.04-lamp.json
-	echo -e "${INFO}Building proboci/ubuntu-16.04-lamp:php-7.0...${NC}"
-	docker build --compress -t="proboci/ubuntu-16.04-lamp:php-7.0" .
-	echo -e "${INFO}Image proboci/ubuntu-16.04-lamp:php-7.0 built.${NC}"
+	echo -e "${INFO}Building proboci/ubuntu-16.04-lamp:php-7.0 and proboci/ubuntu-16.04-lamp:7.0-beta images...${NC}"
+	docker build --compress -t="proboci/ubuntu-16.04-lamp:php-7.0" -t="proboci/ubuntu-16.04-lamp:7.0-beta" .
+	echo -e "${INFO}Images for proboci/ubuntu-16.04-lamp:php-7.0 and proboci/ubuntu-16.04-lamp:7.0-beta built.${NC}"
 }
 
 build_ubuntu-16.04-lamp-php7.1 () {
 	cd $BUILDER/16.04-php7.1
 	$PACKER build ubuntu-16.04-lamp.json
-	echo -e "${INFO}Building proboci/ubuntu-16.04-lamp:php-7.1...${NC}"
-	docker build --compress -t="proboci/ubuntu-16.04-lamp:php-7.1" .
-	echo -e "${INFO}Image proboci/ubuntu-16.04-lamp:php-7.1 built.${NC}"
+	echo -e "${INFO}Building proboci/ubuntu-16.04-lamp:php-7.1 and proboci/ubuntu-16.04-lamp:7.1-beta images...${NC}"
+	docker build --compress -t="proboci/ubuntu-16.04-lamp:php-7.1" -t="proboci/ubuntu-16.04-lamp:7.1-beta" .
+	echo -e "${INFO}Images for proboci/ubuntu-16.04-lamp:php-7.1 and proboci/ubuntu-16.04-lamp:7.1-beta built.${NC}"
 }
 
 build_ubuntu-16.04-lamp-php7.2 () {
 	cd $BUILDER/16.04-php7.2
 	$PACKER build ubuntu-16.04-lamp.json
-	echo -e "${INFO}Building proboci/ubuntu-16.04-lamp:php-7.2...${NC}"
-	docker build --compress -t="proboci/ubuntu-16.04-lamp:php-7.2" .
-	echo -e "${INFO}Image proboci/ubuntu-16.04-lamp:php-7.2 built.${NC}"
+	echo -e "${INFO}Building proboci/ubuntu-16.04-lamp:php-7.2 and proboci/ubuntu-16.04-lamp:7.2-beta images...${NC}"
+	docker build --compress -t="proboci/ubuntu-16.04-lamp:php-7.2" -t="proboci/ubuntu-16.04-lamp:7.2-beta" .
+	echo -e "${INFO}Images for proboci/ubuntu-16.04-lamp:php-7.2 and proboci/ubuntu-16.04-lamp:7.2-beta built.${NC}"
 }
 
 # Build LAMP images.
+# Ubuntu LAMP 14.04 PHP Images
 build_ubuntu-14.04-lamp-php5.5
 build_ubuntu-14.04-lamp-php5.6
 build_ubuntu-14.04-lamp-php7.0
 build_ubuntu-14.04-lamp-php7.1
 build_ubuntu-14.04-lamp-php7.2
+
+# Ubuntu LAMP 16.04 PHP Images
 build_ubuntu-16.04-lamp-php7.0
 build_ubuntu-16.04-lamp-php7.1
 build_ubuntu-16.04-lamp-php7.2

--- a/scripts/export_images.sh
+++ b/scripts/export_images.sh
@@ -137,8 +137,8 @@ export_dotnet-core-images () {
 	export_ubuntu-16.04-dotnet-sdk2.0.2
 }
 
-export_ubuntu-14.04-beta-images
+#export_ubuntu-14.04-beta-images
 export_ubuntu-14.04-stable-images
-export_ubuntu-16.04-beta-images
+#export_ubuntu-16.04-beta-images
 export_ubuntu-16.04-stable-images
 #export_dotnet-core-images

--- a/scripts/export_images.sh
+++ b/scripts/export_images.sh
@@ -10,65 +10,113 @@ rm -f $WORKSPACE/*
 export_ubuntu-14.04-lamp-php5.5 () {
 	docker save proboci/ubuntu-14.04-lamp > $WORKSPACE/ubuntu-14.04-lamp.tar
 	gzip $WORKSPACE/ubuntu-14.04-lamp.tar
+}
 
+export_ubuntu-14.04-lamp-php5.5-beta () {
 	docker save proboci/ubuntu-14.04-lamp:beta > $WORKSPACE/ubuntu-14.04-beta.tar
 	gzip $WORKSPACE/ubuntu-14.04-beta.tar
 }
 
 export_ubuntu-14.04-lamp-php5.6 () {
-	docker save proboci/ubuntu-14.04-lamp:php5.6-nightly > $WORKSPACE/ubuntu-14.04-php5.6-nightly.tar
-	gzip $WORKSPACE/ubuntu-14.04-php5.6-nightly.tar
+	docker save proboci/ubuntu-14.04-lamp:php5.6 > $WORKSPACE/ubuntu-14.04-php5.6.tar
+	gzip $WORKSPACE/ubuntu-14.04-php5.6.tar
+}
+
+export_ubuntu-14.04-lamp-php5.6-beta () {
+	docker save proboci/ubuntu-14.04-lamp:5.6-beta > $WORKSPACE/ubuntu-14.04-php5.6-beta.tar
+	gzip $WORKSPACE/ubuntu-14.04-php5.6.tar
 }
 
 export_ubuntu-14.04-lamp-php7.0 () {
-	docker save proboci/ubuntu-14.04-lamp:php7.0-nightly > $WORKSPACE/ubuntu-14.04-php7.0-nightly.tar
-	gzip $WORKSPACE/ubuntu-14.04-php7.0-nightly.tar
+	docker save proboci/ubuntu-14.04-lamp:php7.0 > $WORKSPACE/ubuntu-14.04-php7.0.tar
+	gzip $WORKSPACE/ubuntu-14.04-php7.0.tar
+}
+
+export_ubuntu-14.04-lamp-php7.0-beta () {
+	docker save proboci/ubuntu-14.04-lamp:7.0-beta > $WORKSPACE/ubuntu-14.04-php7.0-beta.tar
+	gzip $WORKSPACE/ubuntu-14.04-php7.0-beta.tar
 }
 
 export_ubuntu-14.04-lamp-php7.1 () {
-	docker save proboci/ubuntu-14.04-lamp:php7.1-nightly > $WORKSPACE/ubuntu-14.04-php7.1-nightly.tar
-	gzip $WORKSPACE/ubuntu-14.04-php7.1-nightly.tar
+	docker save proboci/ubuntu-14.04-lamp:php7.1 > $WORKSPACE/ubuntu-14.04-php7.1.tar
+	gzip $WORKSPACE/ubuntu-14.04-php7.1.tar
+}
+
+export_ubuntu-14.04-lamp-php7.1-beta () {
+	docker save proboci/ubuntu-14.04-lamp:7.1-beta > $WORKSPACE/ubuntu-14.04-php7.1-beta.tar
+	gzip $WORKSPACE/ubuntu-14.04-php7.1-beta.tar
 }
 
 export_ubuntu-14.04-lamp-php7.2 () {
-	docker save proboci/ubuntu-14.04-lamp:php7.2-nightly > $WORKSPACE/ubuntu-14.04-php7.2-nightly.tar
-	gzip $WORKSPACE/ubuntu-14.04-php7.2-nightly.tar
+	docker save proboci/ubuntu-14.04-lamp:php7.2 > $WORKSPACE/ubuntu-14.04-php7.2.tar
+	gzip $WORKSPACE/ubuntu-14.04-php7.2.tar
+}
+
+export_ubuntu-14.04-lamp-php7.2-beta () {
+	docker save proboci/ubuntu-14.04-lamp:7.2-beta > $WORKSPACE/ubuntu-14.04-php7.2-beta.tar
+	gzip $WORKSPACE/ubuntu-14.04-php7.2-beta.tar
 }
 
 export_ubuntu-16.04-dotnet-sdk1.0.1 () {
-	docker save proboci/ubuntu-16.04-dotnet:sdk1.0.1-nightly > $WORKSPACE/ubuntu-16.04-dotnetsdk1.0.1-nightly.tar
-	gzip $WORKSPACE/ubuntu-16.04-dotnetsdk1.0.1-nightly.tar
+	docker save proboci/ubuntu-16.04-dotnet:sdk1.0.1 > $WORKSPACE/ubuntu-16.04-dotnetsdk1.0.1.tar
+	gzip $WORKSPACE/ubuntu-16.04-dotnetsdk1.0.1.tar
 }
 
 export_ubuntu-16.04-dotnet-sdk2.0.2 () {
-	docker save proboci/ubuntu-16.04-dotnet:sdk2.0.2-nightly > $WORKSPACE/ubuntu-16.04-dotnetsdk2.0.2-nightly.tar
-	gzip $WORKSPACE/ubuntu-16.04-dotnetsdk2.0.2-nightly.tar
+	docker save proboci/ubuntu-16.04-dotnet:sdk2.0.2 > $WORKSPACE/ubuntu-16.04-dotnetsdk2.0.2.tar
+	gzip $WORKSPACE/ubuntu-16.04-dotnetsdk2.0.2.tar
 }
 
 export_ubuntu-16.04-lamp-php7.0 () {
-	docker save proboci/ubuntu-16.04-lamp:php7.0-nightly > $WORKSPACE/ubuntu-16.04-php7.0-nightly.tar
-	gzip $WORKSPACE/ubuntu-16.04-php7.0-nightly.tar
+	docker save proboci/ubuntu-16.04-lamp:php7.0 > $WORKSPACE/ubuntu-16.04-php7.0.tar
+	gzip $WORKSPACE/ubuntu-16.04-php7.0.tar
+}
+
+export_ubuntu-16.04-lamp-php7.0-beta () {
+	docker save proboci/ubuntu-16.04-lamp:7.0-beta > $WORKSPACE/ubuntu-16.04-php7.0-beta.tar
+	gzip $WORKSPACE/ubuntu-16.04-php7.0-beta.tar
 }
 
 export_ubuntu-16.04-lamp-php7.1 () {
-	docker save proboci/ubuntu-16.04-lamp:php7.1-nightly > $WORKSPACE/ubuntu-16.04-php7.1-nightly.tar
-	gzip $WORKSPACE/ubuntu-16.04-php7.1-nightly.tar
+	docker save proboci/ubuntu-16.04-lamp:php7.1 > $WORKSPACE/ubuntu-16.04-php7.1.tar
+	gzip $WORKSPACE/ubuntu-16.04-php7.1.tar
+}
+
+export_ubuntu-16.04-lamp-php7.1-beta () {
+	docker save proboci/ubuntu-16.04-lamp:7.1-beta > $WORKSPACE/ubuntu-16.04-php7.1-beta.tar
+	gzip $WORKSPACE/ubuntu-16.04-php7.1-beta.tar
 }
 
 export_ubuntu-16.04-lamp-php7.2 () {
-	docker save proboci/ubuntu-16.04-lamp:php7.2-nightly > $WORKSPACE/ubuntu-16.04-php7.2-nightly.tar
-	gzip $WORKSPACE/ubuntu-16.04-php7.2-nightly.tar
+	docker save proboci/ubuntu-16.04-lamp:php7.2 > $WORKSPACE/ubuntu-16.04-php7.2.tar
+	gzip $WORKSPACE/ubuntu-16.04-php7.2.tar
+}
+
+export_ubuntu-16.04-lamp-php7.2-beta () {
+	docker save proboci/ubuntu-16.04-lamp:7.2-beta > $WORKSPACE/ubuntu-16.04-php7.2-beta.tar
+	gzip $WORKSPACE/ubuntu-16.04-php7.2-beta.tar
 }
 
 # Export LAMP images.
+# Ubuntu LAMP 14.04 PHP Images
 export_ubuntu-14.04-lamp-php5.5
+export_ubuntu-14.04-lamp-php5.5-beta
 export_ubuntu-14.04-lamp-php5.6
+export_ubuntu-14.04-lamp-php5.6-beta
 export_ubuntu-14.04-lamp-php7.0
+export_ubuntu-14.04-lamp-php7.0-beta
 export_ubuntu-14.04-lamp-php7.1
+export_ubuntu-14.04-lamp-php7.1-beta
 export_ubuntu-14.04-lamp-php7.2
+export_ubuntu-14.04-lamp-php7.2-beta
+
+# Ubuntu LAMP 16.04 PHP Images
 export_ubuntu-16.04-lamp-php7.0
+export_ubuntu-16.04-lamp-php7.0-beta
 export_ubuntu-16.04-lamp-php7.1
+export_ubuntu-16.04-lamp-php7.1-beta
 export_ubuntu-16.04-lamp-php7.2
+export_ubuntu-16.04-lamp-php7.2-beta
 
 # Export .NET images.
 #export_ubuntu-16.04-dotnet-sdk1.0.1

--- a/scripts/export_images.sh
+++ b/scripts/export_images.sh
@@ -7,6 +7,14 @@ WORKSPACE=/vagrant/workspace
 
 rm -f $WORKSPACE/*
 
+export_ubuntu-14.04-lamp-php5.5 () {
+	docker save proboci/ubuntu-14.04-lamp > $WORKSPACE/ubuntu-14.04-lamp.tar
+	gzip $WORKSPACE/ubuntu-14.04-lamp.tar
+
+	docker save proboci/ubuntu-14.04-lamp:beta > $WORKSPACE/ubuntu-14.04-beta.tar
+	gzip $WORKSPACE/ubuntu-14.04-beta.tar
+}
+
 export_ubuntu-14.04-lamp-php5.6 () {
 	docker save proboci/ubuntu-14.04-lamp:php5.6-nightly > $WORKSPACE/ubuntu-14.04-php5.6-nightly.tar
 	gzip $WORKSPACE/ubuntu-14.04-php5.6-nightly.tar
@@ -53,6 +61,7 @@ export_ubuntu-16.04-lamp-php7.2 () {
 }
 
 # Export LAMP images.
+export_ubuntu-14.04-lamp-php5.5
 export_ubuntu-14.04-lamp-php5.6
 export_ubuntu-14.04-lamp-php7.0
 export_ubuntu-14.04-lamp-php7.1
@@ -62,5 +71,5 @@ export_ubuntu-16.04-lamp-php7.1
 export_ubuntu-16.04-lamp-php7.2
 
 # Export .NET images.
-export_ubuntu-16.04-dotnet-sdk1.0.1
-export_ubuntu-16.04-dotnet-sdk2.0.2
+#export_ubuntu-16.04-dotnet-sdk1.0.1
+#export_ubuntu-16.04-dotnet-sdk2.0.2

--- a/scripts/export_images.sh
+++ b/scripts/export_images.sh
@@ -97,27 +97,48 @@ export_ubuntu-16.04-lamp-php7.2-beta () {
 	gzip $WORKSPACE/ubuntu-16.04-php7.2-beta.tar
 }
 
-# Export LAMP images.
-# Ubuntu LAMP 14.04 PHP Images
-export_ubuntu-14.04-lamp-php5.5
-export_ubuntu-14.04-lamp-php5.5-beta
-export_ubuntu-14.04-lamp-php5.6
-export_ubuntu-14.04-lamp-php5.6-beta
-export_ubuntu-14.04-lamp-php7.0
-export_ubuntu-14.04-lamp-php7.0-beta
-export_ubuntu-14.04-lamp-php7.1
-export_ubuntu-14.04-lamp-php7.1-beta
-export_ubuntu-14.04-lamp-php7.2
-export_ubuntu-14.04-lamp-php7.2-beta
+export_ubuntu-14.04-beta-images (){
+	# Export Ubuntu LAMP 14.04 PHP Beta Images
+	export_ubuntu-14.04-lamp-php5.5-beta
+	export_ubuntu-14.04-lamp-php5.6-beta
+	export_ubuntu-14.04-lamp-php7.0-beta
+	export_ubuntu-14.04-lamp-php7.1-beta
+	export_ubuntu-14.04-lamp-php7.2-beta
+}
 
-# Ubuntu LAMP 16.04 PHP Images
-export_ubuntu-16.04-lamp-php7.0
-export_ubuntu-16.04-lamp-php7.0-beta
-export_ubuntu-16.04-lamp-php7.1
-export_ubuntu-16.04-lamp-php7.1-beta
-export_ubuntu-16.04-lamp-php7.2
-export_ubuntu-16.04-lamp-php7.2-beta
+export_ubuntu-14.04-stable-images () {
+	# Export Ubuntu LAMP 14.04 PHP Stable Images
+	export_ubuntu-14.04-lamp-php5.5
+	export_ubuntu-14.04-lamp-php5.6
+	export_ubuntu-14.04-lamp-php7.0
+	export_ubuntu-14.04-lamp-php7.1
+	export_ubuntu-14.04-lamp-php7.2
 
-# Export .NET images.
-#export_ubuntu-16.04-dotnet-sdk1.0.1
-#export_ubuntu-16.04-dotnet-sdk2.0.2
+}
+
+export_ubuntu-16.04-beta-images () {
+	# Export Ubuntu LAMP 16.04 PHP Beta Images
+	export_ubuntu-16.04-lamp-php7.0-beta
+	export_ubuntu-16.04-lamp-php7.1-beta
+	export_ubuntu-16.04-lamp-php7.2-beta
+}
+
+export_ubuntu-16.04-stable-images () {
+	# Ubuntu LAMP 16.04 PHP Images
+	export_ubuntu-16.04-lamp-php7.0
+	export_ubuntu-16.04-lamp-php7.1
+	export_ubuntu-16.04-lamp-php7.2
+}
+
+
+export_dotnet-core-images () {
+	# Export .NET Core images.
+	export_ubuntu-16.04-dotnet-sdk1.0.1
+	export_ubuntu-16.04-dotnet-sdk2.0.2
+}
+
+export_ubuntu-14.04-beta-images
+export_ubuntu-14.04-stable-images
+export_ubuntu-16.04-beta-images
+export_ubuntu-16.04-stable-images
+#export_dotnet-core-images

--- a/scripts/export_images.sh
+++ b/scripts/export_images.sh
@@ -8,8 +8,8 @@ WORKSPACE=/vagrant/workspace
 rm -f $WORKSPACE/*
 
 export_ubuntu-14.04-lamp-php5.5 () {
-	docker save proboci/ubuntu-14.04-lamp > $WORKSPACE/ubuntu-14.04-lamp.tar
-	gzip $WORKSPACE/ubuntu-14.04-lamp.tar
+	docker save proboci/ubuntu-14.04-lamp:latest > $WORKSPACE/ubuntu-14.04-lamp-latest.tar
+	gzip $WORKSPACE/ubuntu-14.04-lamp-latest.tar
 }
 
 export_ubuntu-14.04-lamp-php5.5-beta () {


### PR DESCRIPTION
This PR adds a new PHP 5.5 version of the ansible provisioner, which allows us to update the default probo image for use with the ansible provisioner.

It also makes adjustments to the build and export scripts to allow for easy provisioning of just a set of images such as the 14.04 LAMP stable images or 16.04 LAMP beta images.