### PR TITLE
Fix mysql startup errors.

### DIFF
--- a/ansible/roles/ubuntu-mysql/tasks/main.yml
+++ b/ansible/roles/ubuntu-mysql/tasks/main.yml
@@ -5,6 +5,22 @@
   with_items:
     - 'mysql-server'
 
+- name: ensure mysql data directory exists
+  file:
+    path: '/var/lib/mysql'
+    state: 'directory'
+    owner: 'mysql'
+    group: 'mysql'
+    mode: 0755
+
+- name: ensure drush run directory exists
+  file:
+    path: '/var/run/mysqld'
+    state: 'directory'
+    owner: 'mysql'
+    group: 'mysql'
+    mode: 0755
+
 - name: start mysql service
   shell: service mysql start
 


### PR DESCRIPTION
We are receiving errors in some situations when starting mysqld_safe. Setting the ownership of the mysql data and run directories fixed it locally. Needs official testing.