### PR TITLE
Update Drush to latest version

### DIFF
--- a/ansible/roles/ubuntu-probo/tasks/drupal-tools.yml
+++ b/ansible/roles/ubuntu-probo/tasks/drupal-tools.yml
@@ -2,7 +2,7 @@
 
 - name: install drush
   get_url:
-    url: https://github.com/drush-ops/drush/releases/download/8.1.11/drush.phar
+    url: https://github.com/drush-ops/drush/releases/download/8.1.18/drush.phar
     dest: /usr/local/bin/drush
     mode: 0755
 


### PR DESCRIPTION
The copy of Drush included in the Probo docker images (8.1.11) has several PHP 7.2 issues that have been addressed in more recent Drush 8.1.x releases.

We've encountered this specific issue in some of our ProboCI builds but there are several other PHP 7.2-specific issues that have been addressed in the latest 8.1.x Drush release as well:
https://github.com/drush-ops/drush/issues/3351